### PR TITLE
Potential fix for code scanning alert no. 1: Encryption using ECB

### DIFF
--- a/PKHeX.Core/Saves/Encryption/MemeCrypto/MemeKey.cs
+++ b/PKHeX.Core/Saves/Encryption/MemeCrypto/MemeKey.cs
@@ -131,7 +131,9 @@ public readonly ref struct MemeKey
 
         // Don't dispose in this method, let the consumer dispose.
         // no IV -- all zero.
-        return RuntimeCryptographyProvider.Aes.Create(key, CipherMode.ECB, PaddingMode.None);
+        var iv = new byte[16]; // AES block size is 16 bytes
+        RandomNumberGenerator.Fill(iv); // Generate a random IV
+        return RuntimeCryptographyProvider.Aes.Create(key, CipherMode.CBC, PaddingMode.None, iv);
     }
 
     /// <summary>


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/PKHeX-ALL-IN-ONE/security/code-scanning/1](https://github.com/Xieons-Gaming-Corner/PKHeX-ALL-IN-ONE/security/code-scanning/1)

To fix the issue, replace `CipherMode.ECB` with a more secure mode, such as `CipherMode.CBC`. CBC mode requires an initialization vector (IV) to ensure that identical plaintext blocks produce different ciphertext blocks. This IV should be randomly generated for each encryption operation and securely transmitted or stored alongside the ciphertext.

Changes required:
1. Update the `GetAesImpl` method to use `CipherMode.CBC` instead of `CipherMode.ECB`.
2. Generate a random IV for encryption and ensure it is passed to the AES implementation.
3. Modify the decryption logic to use the same IV that was used during encryption.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
