### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/plugin-release.yml
+++ b/.github/workflows/plugin-release.yml
@@ -1,4 +1,6 @@
 name: Auto-Release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Xieons-Gaming-Corner/PKHeX-ALL-IN-ONE/security/code-scanning/3](https://github.com/Xieons-Gaming-Corner/PKHeX-ALL-IN-ONE/security/code-scanning/3)

To fix the problem, add an explicit `permissions:` block to the workflow which grants only the minimal permissions needed for it to execute successfully. For workflows that use the `gh release` command to create and modify releases, at minimum, "contents: write" is needed. As a best practice, place the `permissions:` block at the root level, immediately under the workflow `name: ...` line, so all jobs inherit it unless overridden. No functionality changes are needed; just add the explicit block. You should NOT add excess write permissions to other scopes unless a step requires them.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
